### PR TITLE
Fix code scanning alert no. 12: Use of a broken or risky cryptographic algorithm

### DIFF
--- a/jdevelops-apis/jdevelops-apis-sign/src/main/java/cn/tannn/jdevelops/sign/util/SignMD5Util.java
+++ b/jdevelops-apis/jdevelops-apis-sign/src/main/java/cn/tannn/jdevelops/sign/util/SignMD5Util.java
@@ -21,7 +21,7 @@ import java.util.Map;
 public class SignMD5Util {
 
     private final static Integer THIRTY_TWO = 32;
-    public static final String MD_5 = "md5";
+    public static final String SHA_256 = "SHA-256";
 
     public static String encrypt(String plainText) {
         return encrypt(plainText,true);
@@ -39,7 +39,7 @@ public class SignMD5Util {
         }
         byte[] secretBytes ;
         try {
-            secretBytes = MessageDigest.getInstance(MD_5).digest(
+            secretBytes = MessageDigest.getInstance(SHA_256).digest(
                     plainText.getBytes(StandardCharsets.UTF_8)  );
         } catch (Exception e) {
             throw new SignException("没有md5这个算法！",e);


### PR DESCRIPTION
Fixes [https://github.com/en-o/Jdevelops/security/code-scanning/12](https://github.com/en-o/Jdevelops/security/code-scanning/12)

To fix the problem, we need to replace the use of the MD5 algorithm with a stronger cryptographic algorithm. A suitable replacement is SHA-256, which is part of the SHA-2 family and is considered secure for most applications.

- Replace the `MD_5` constant with a new constant for SHA-256.
- Update the `MessageDigest.getInstance` call to use SHA-256 instead of MD5.
- Ensure that the rest of the code remains functionally equivalent, as SHA-256 will produce a different length hash compared to MD5.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
