### PR TITLE
Fix code scanning alert no. 23: Use of RSA algorithm without OAEP

### DIFF
--- a/jdevelops-frameworks/jdevelops-spring-boot-starter/src/main/java/cn/tannn/jdevelops/frameworks/web/starter/apiSecurity/ApiRSAUtils.java
+++ b/jdevelops-frameworks/jdevelops-spring-boot-starter/src/main/java/cn/tannn/jdevelops/frameworks/web/starter/apiSecurity/ApiRSAUtils.java
@@ -102,7 +102,7 @@ public class ApiRSAUtils {
     public static byte[] encryptByPublicKey(byte[] data, String publicKey) throws Exception {
         //base64格式的key字符串转Key对象
         Key publicK = KeyFactory.getInstance(KEY_ALGORITHM).generatePublic(new X509EncodedKeySpec(Base64.decodeBase64(publicKey)));
-        Cipher cipher = Cipher.getInstance(ALGORITHMS);
+        Cipher cipher = Cipher.getInstance("RSA/ECB/OAEPWithSHA-1AndMGF1Padding");
         cipher.init(Cipher.ENCRYPT_MODE, publicK);
         //分段进行加密操作
         return encryptAndDecryptOfSubsection(data, cipher, MAX_ENCRYPT_BLOCK);
@@ -117,7 +117,7 @@ public class ApiRSAUtils {
     public static byte[] pubKeyDec(byte[] data, String publicKey) throws Exception {
         //base64格式的key字符串转Key对象
         Key privateK = KeyFactory.getInstance(KEY_ALGORITHM).generatePublic(new X509EncodedKeySpec(Base64.decodeBase64(publicKey)));
-        Cipher cipher = Cipher.getInstance(ALGORITHMS);
+        Cipher cipher = Cipher.getInstance("RSA/ECB/OAEPWithSHA-1AndMGF1Padding");
         cipher.init(Cipher.DECRYPT_MODE, privateK);
 
         //分段进行解密操作
@@ -135,7 +135,7 @@ public class ApiRSAUtils {
 
         //base64格式的key字符串转Key对象
         Key publicK = KeyFactory.getInstance(KEY_ALGORITHM).generatePrivate(new PKCS8EncodedKeySpec(Base64.decodeBase64(privateKey)));
-        Cipher cipher = Cipher.getInstance(ALGORITHMS);
+        Cipher cipher = Cipher.getInstance("RSA/ECB/OAEPWithSHA-1AndMGF1Padding");
         cipher.init(Cipher.ENCRYPT_MODE, publicK);
 
         //分段进行加密操作


### PR DESCRIPTION
Fixes [https://github.com/en-o/Jdevelops/security/code-scanning/23](https://github.com/en-o/Jdevelops/security/code-scanning/23)

To fix the problem, we need to ensure that the RSA encryption uses OAEP padding. This can be done by specifying the padding scheme explicitly when initializing the `Cipher` instance. The best way to fix this without changing existing functionality is to replace the `ALGORITHMS` variable with the explicit string `"RSA/ECB/OAEPWithSHA-1AndMGF1Padding"`.

We need to make changes in the `encryptByPublicKey`, `pubKeyDec`, and `privKeyEnc` methods to use the OAEP padding scheme.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
