### PR TITLE
Fix code scanning alert no. 25: Use of a broken or risky cryptographic algorithm

### DIFF
--- a/jdevelops-frameworks/jdevelops-spring-boot-starter/src/main/java/cn/tannn/jdevelops/frameworks/web/starter/apiSecurity/ApiAESUtils.java
+++ b/jdevelops-frameworks/jdevelops-spring-boot-starter/src/main/java/cn/tannn/jdevelops/frameworks/web/starter/apiSecurity/ApiAESUtils.java
@@ -29,7 +29,7 @@ public class ApiAESUtils {
      * 算法名称/加密模式/数据填充方式
      * 默认：AES/ECB/PKCS5Padding
      */
-    private static final String ALGORITHMS = "AES/ECB/PKCS5Padding";
+    private static final String ALGORITHMS = "AES/CBC/PKCS5Padding";
 
     /**
      * 后端AES的key，由静态代码块赋值
@@ -80,11 +80,20 @@ public class ApiAESUtils {
     public static String encrypt(String content, String encryptKey) throws Exception {
         //设置Cipher对象
         Cipher cipher = Cipher.getInstance(ALGORITHMS);
-        cipher.init(Cipher.ENCRYPT_MODE, new SecretKeySpec(encryptKey.getBytes(), KEY_ALGORITHM));
+        byte[] iv = new byte[16];
+        SecureRandom random = new SecureRandom();
+        random.nextBytes(iv);
+        IvParameterSpec ivParameterSpec = new IvParameterSpec(iv);
+        cipher.init(Cipher.ENCRYPT_MODE, new SecretKeySpec(encryptKey.getBytes(), KEY_ALGORITHM), ivParameterSpec);
 
         //调用doFinal
+        byte[] encryptedBytes = cipher.doFinal(content.getBytes(StandardCharsets.UTF_8));
+        byte[] encryptedWithIv = new byte[iv.length + encryptedBytes.length];
+        System.arraycopy(iv, 0, encryptedWithIv, 0, iv.length);
+        System.arraycopy(encryptedBytes, 0, encryptedWithIv, iv.length, encryptedBytes.length);
+
         // 转base64
-        return Base64.encodeBase64String(cipher.doFinal(content.getBytes(StandardCharsets.UTF_8)));
+        return Base64.encodeBase64String(encryptedWithIv);
 
     }
 
@@ -101,9 +110,15 @@ public class ApiAESUtils {
 
         //设置Cipher对象
         Cipher cipher = Cipher.getInstance(ALGORITHMS);
-        cipher.init(Cipher.DECRYPT_MODE, new SecretKeySpec(decryptKey.getBytes(), KEY_ALGORITHM));
+        byte[] iv = new byte[16];
+        System.arraycopy(decodeBase64, 0, iv, 0, iv.length);
+        IvParameterSpec ivParameterSpec = new IvParameterSpec(iv);
+        byte[] encryptedBytes = new byte[decodeBase64.length - iv.length];
+        System.arraycopy(decodeBase64, iv.length, encryptedBytes, 0, encryptedBytes.length);
+
+        cipher.init(Cipher.DECRYPT_MODE, new SecretKeySpec(decryptKey.getBytes(), KEY_ALGORITHM), ivParameterSpec);
         //调用doFinal解密
-        return new String(cipher.doFinal(decodeBase64));
+        return new String(cipher.doFinal(encryptedBytes));
 
 }
 }


### PR DESCRIPTION
Fixes [https://github.com/en-o/Jdevelops/security/code-scanning/25](https://github.com/en-o/Jdevelops/security/code-scanning/25)

To fix the problem, we need to replace the insecure ECB mode with a more secure mode such as CBC or GCM. This involves updating the `ALGORITHMS` constant to use "AES/CBC/PKCS5Padding" or "AES/GCM/NoPadding". Additionally, when using CBC mode, we need to handle an initialization vector (IV) for encryption and decryption.

- Update the `ALGORITHMS` constant to use "AES/CBC/PKCS5Padding".
- Generate a random IV for encryption and include it with the ciphertext.
- Extract the IV from the ciphertext for decryption.
- Update the encryption and decryption methods to handle the IV.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
